### PR TITLE
Call InstantRst with '-d' option to serve files from specified directories

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,8 +110,6 @@ g:instant_rst_localhost_only
 
     Whenever your vim has '+py'
 
-
-
 g:instant_rst_forever 
     Always preview all rst buffer, default is ``0``.
 
@@ -121,6 +119,16 @@ g:instant_rst_bind_scroll
     When scrolling with Vim, The browser will scroll either.
 
     default is ``1``
+
+g:instant_rst_additional_dirs
+    Serve additional directories for previewing, default is an empty array ``[]``.
+
+    For example: ``['/home/<my_user>/<my_rst_project>/images', '/home/<my_user>/<my_rst_project>/docs']``
+
+    It requires the absolute path of the directory, and the last directory name is used in the server.
+
+    A request made to ``/images/cats/1.png`` will try to serve the file from ``/home/<my_user>/<my_rst_project>/images/cats/1.png``
+
 
 TODO
 ----

--- a/after/ftplugin/rst/instantRst.vim
+++ b/after/ftplugin/rst/instantRst.vim
@@ -35,6 +35,10 @@ if !exists('g:instant_rst_localhost_only')
     let g:instant_rst_localhost_only = 0
 endif
 
+if !exists('g:instant_rst_additional_dirs')
+    let g:instant_rst_additional_dirs = []
+endif
+
 if !exists('g:_instant_rst_daemon_started')
     let g:_instant_rst_daemon_started = 0
 endif
@@ -87,6 +91,11 @@ function! s:startDaemon(file) "{{{
                     \ ' -f '.a:file : ''
         let args_local = g:instant_rst_localhost_only == 1 ? 
                     \ ' -l ' : ''
+        let args_additional_dirs = ''
+
+        for directory in g:instant_rst_additional_dirs
+            let args_additional_dirs .= ' -d '.directory
+        endfor
 
         let  cmd = "instantRst "
                     \.args_browser
@@ -95,6 +104,7 @@ function! s:startDaemon(file) "{{{
                     \.args_static
                     \.args_template
                     \.args_local
+                    \.args_additional_dirs
                     \.' &>/dev/null'
                     \.' &'
         call s:system(cmd)


### PR DESCRIPTION
The variable `g:instant_rst_additional_dirs` must be set before calling `:InstantRst`