### PR TITLE
Support files which includes spaces in filename

### DIFF
--- a/after/ftplugin/rst/instantRst.vim
+++ b/after/ftplugin/rst/instantRst.vim
@@ -88,7 +88,7 @@ function! s:startDaemon(file) "{{{
         let args_template = g:instant_rst_template != '' ? 
                     \ ' -t '.g:instant_rst_template : ''
         let args_file = a:file != '' ? 
-                    \ ' -f '.a:file : ''
+                    \ ' -f '.substitute(a:file, ' ', '\\ ', 'g') : ''
         let args_local = g:instant_rst_localhost_only == 1 ? 
                     \ ' -l ' : ''
         let args_additional_dirs = ''


### PR DESCRIPTION
* I think changing the filename to \"a.file\" maybe general for windows/linux/osx. I don't test it in windows.